### PR TITLE
Don't generate nested input fields that are relying on default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
+[![Example Code header](https://github.com/newrelic/open-source-office/raw/master/examples/categories/images/Example_Code.png)](https://github.com/newrelic/open-source-office/blob/master/examples/categories/index.md#category-example-code)
+
 # Absinthe Schema Stitching Example
 
 ### Support Statement
-
-**This is an unsupported example. This project is provided AS-IS WITHOUT
-WARRANTY OR SUPPORT.**
 
 This repository contains three example Absinthe-GraphQL applications. The primary `Soccer Team` application and the secondary `Events` application are both independent GraphQL APIs. The Schema Stitch application demonstrates the process of stitching the Events application GraphQL schema into the main Soccer Team application GraphQL schema. Through this automated schema-stitching process, schemas from any downstream GraphQL application can be seamlessly integrated into upstream schemas with little manual interaction.
 

--- a/apps/schema_stitch/lib/query_generator.ex
+++ b/apps/schema_stitch/lib/query_generator.ex
@@ -255,7 +255,8 @@ defmodule SchemaStitch.QueryGenerator do
   defp build_input_value(%Blueprint.Input.Value{
          normalized: %Blueprint.Input.Object{fields: sub_fields}
        }) do
-    "{ #{build_input_args(sub_fields)} }"
+    used_sub_fields = exclude_args_with_default_values(sub_fields)
+    "{ #{build_input_args(used_sub_fields)} }"
   end
 
   defp build_input_value(%Blueprint.Input.Value{

--- a/apps/schema_stitch/test/query_generator_test.exs
+++ b/apps/schema_stitch/test/query_generator_test.exs
@@ -32,7 +32,7 @@ defmodule SchemaStitch.QueryGeneratorTest do
 
     input_object :school_input_object do
       field(:grade_levels, list_of(:integer))
-      field(:zipcode, :string)
+      field(:zipcode, non_null(:string), default_value: "90210")
     end
 
     input_object :farmers_market_input_object do
@@ -274,6 +274,24 @@ defmodule SchemaStitch.QueryGeneratorTest do
                  %{day_of_the_week: "Saturday", neighborhood: "Multnomah Village"}
                ]
              }
+    end
+
+    test "with input object relying on defaults" do
+      {generated_query, _used_vars} =
+        """
+        {
+          schools(schoolInputObject: { gradeLevels: [ 1, 2 ] })
+        }
+        """
+        |> externalize()
+
+      assert generated_query ==
+               """
+               query {
+                 schools(schoolInputObject: { gradeLevels: [ 1, 2 ] })
+               }
+               """
+               |> String.trim()
     end
   end
 


### PR DESCRIPTION
We accounted for top-level input fields relying on default values, but not nested input fields relying on default values.